### PR TITLE
fix: create table error for migrate

### DIFF
--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -188,7 +188,7 @@ func (m *Migrate) createMigrationTableIfNotExists() error {
 		return nil
 	}
 
-	sql := fmt.Sprintf("CREATE TABLE %s (%s VARCHAR(255) PRIMARY KEY)", m.options.TableName, m.options.IDColumnName)
+	sql := fmt.Sprintf("CREATE TABLE %s (%s VARCHAR(100) PRIMARY KEY)", m.options.TableName, m.options.IDColumnName)
 	if _, err := m.db.Exec(sql); err != nil {
 		return err
 	}


### PR DESCRIPTION
mysql error-Specified key was too long; max key length is 767 bytes when using utf8mb4-general-ci,innodb, mysql@5.7.